### PR TITLE
AMD changes + opti

### DIFF
--- a/LibreHardwareHelper/LibreHardwareHelper/LibreHardwareHelper.cs
+++ b/LibreHardwareHelper/LibreHardwareHelper/LibreHardwareHelper.cs
@@ -99,7 +99,7 @@ public class LibreHardwareHelper : IDisposable
 
         var coreBuilders = new Dictionary<int, CpuCoreBuilder>();
 
-        var coreRelatedInfo = cpu.Sensors.Where(x => x.Name.ToLower().Contains("Core #")).ToArray();
+        var coreRelatedInfo = cpu.Sensors.Where(x => x.Name.ToLower().Contains("core #")).ToArray();
 
         // seems to be a consistent way to get only physical cores across types
         var coreCount = coreRelatedInfo.Count(x => x.SensorType == SensorType.Clock);
@@ -142,7 +142,6 @@ public class LibreHardwareHelper : IDisposable
 
             coreBuilders[s.Index] = builder;
         }
-
 
         foreach (var builder in coreBuilders.Values) cores.Add(builder.Build());
 

--- a/LibreHardwareHelper/LibreHardwareHelper/Model/HardwareData/CPU/CpuTemp.cs
+++ b/LibreHardwareHelper/LibreHardwareHelper/Model/HardwareData/CPU/CpuTemp.cs
@@ -44,7 +44,7 @@ public class CpuTemp : PropertyNotifierBase
                     CoreAverage = s.Value ?? 0;
                     break;
                 }
-                case "Core (Tct1/Tdie)":
+                case "Core (Tctl/Tdie)":
                 {
                     CoreAverage = s.Value ?? 0;
                     break;

--- a/LibreHardwareHelper/LibreHardwareHelper/Model/HardwareData/CPU/CpuTemp.cs
+++ b/LibreHardwareHelper/LibreHardwareHelper/Model/HardwareData/CPU/CpuTemp.cs
@@ -26,6 +26,7 @@ public class CpuTemp : PropertyNotifierBase
 
             switch (s.Name)
             {
+                case "CCD1 (Tdie)":
                 case "CPU Package":
                 {
                     //add pacakge temp
@@ -38,20 +39,11 @@ public class CpuTemp : PropertyNotifierBase
                     CoreMaxTemp = s.Value ?? 0;
                     break;
                 }
+                case "Core (Tctl/Tdie)":
                 case "Core Average":
                 {
                     //add cpu average temp
                     CoreAverage = s.Value ?? 0;
-                    break;
-                }
-                case "Core (Tctl/Tdie)":
-                {
-                    CoreAverage = s.Value ?? 0;
-                    break;
-                }
-                case "CCD1 (Tdie)":
-                {
-                    PackageTemp = s.Value ?? 0;
                     break;
                 }
             }

--- a/LibreHardwareHelper/LibreHardwareHelper/Model/HardwareData/CPU/CpuTemp.cs
+++ b/LibreHardwareHelper/LibreHardwareHelper/Model/HardwareData/CPU/CpuTemp.cs
@@ -11,6 +11,7 @@ public class CpuTemp : PropertyNotifierBase
 
     private float _packageTemp;
 
+    // TODO: opinion on toLowering the strings?
     public CpuTemp(IHardware cpu, LibreHardwareHelper helper)
     {
         if (cpu == null) return;
@@ -41,6 +42,16 @@ public class CpuTemp : PropertyNotifierBase
                 {
                     //add cpu average temp
                     CoreAverage = s.Value ?? 0;
+                    break;
+                }
+                case "Core (Tct1/Tdie)":
+                {
+                    CoreAverage = s.Value ?? 0;
+                    break;
+                }
+                case "CCD1 (Tdie)":
+                {
+                    PackageTemp = s.Value ?? 0;
                     break;
                 }
             }


### PR DESCRIPTION
Change prephardware to go straight for firstDefault, seems un-needed to "filter" then first
AMD sensors are partly only "core #1" so changed to contains with lower()
Use a count to ignore threads,

needs testing on intel still tho

